### PR TITLE
Extend i2c.py with SMBus2 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 dist
 .DS_Store
+.venv

--- a/src/greenpak/i2c.py
+++ b/src/greenpak/i2c.py
@@ -91,22 +91,55 @@ class GreenPakI2cDriver(GreenPakI2cInterface):
 class GreenPackSMBusAdapter(GreenPakI2cInterface):
     """An adpater to the Linux 'native' SMBus interface"""
     import smbus2
+    from smbus2 import smbus2
 
     def __init__(self, i2cbusdev="/dev/i2c-0"):
         self.bus = self.smbus2.SMBus(i2cbusdev)
+        self.isopen = True
+
+    def __del__(self):
+        if self.isopen:
+            self.bus.close()
+
+    def __empty_wr(self, addr: int):
+        #The purpose of this is to probe for a slave at address, in a non-destuctive
+        #way. With SMBus layer, we could use write_quick(), provided implementation
+        #doesn't do/send anything beyond:
+        #
+        # " .... When using write_quick, the slave address is sent along with the read/write bit. 
+        #        No additional data is transmitted. The read/write bit can be used to convey some 
+        #        simple information. For instance, you might use the read/write bit to signal a 
+        #        '1' or '0' to the device .... "
+        #  (More details see for e.g.: https://www.nxp.com/docs/en/application-note/AN4471.pdf)
+        #
+        #The SMBus2 Linux/Python library provides interface for quick write only.
+        #(A properly working 'quick' command should properly stop (send stop bit) transaction
+        # after n/ack  received, not leaving in some unfinished state).
+        self.bus.write_quick(addr)  #Can/will throw If no device at address
+
+    def __empty_rd(self, addr: int):
+        #A 'quick read' is not provided by SMBus layer because it is not universaly safe (e.g. as
+        #I tested, SLG would hold the bus hostage until its reset.)[ google more for info ].
+        #For an SLG, whichever memory block -reg,nvm,eeprom - we addressing, a read without
+        #first setting the data pointer should be safe, as it will return data from last
+        #address set through a previous read/write reqest. We discard the result.
+        self.bus._set_address(addr, None)
+        msg = self.smbus2.i2c_msg.read(address=addr, length=1)
+        self.bus.i2c_rdwr(msg)
 
     @override
     def write(self, addr: int, data: bytearray, silent: bool = False) -> bool:
         try:
             if 0 == len(data):
-                #assume caller probing for GP devs on bus
-                self.bus.write_quick(addr)  #Can throw
+                #special case as we not actually writing/sending data.
+                #(assume caller probing for GP devs on bus).
+                self.__empty_wr(addr)  #Can throw
             else:
                 #assume data is sent/written
                 self.bus.write_i2c_block_data(addr, data[0], data[1:])
         except Exception as e:
             if not silent:
-                str = "SMBus: while writing to add 0x%02x: caught exception: %s" % (addr, e)
+                str = "SMBus: while writing to addr 0x%02x: caught exception: %s" % (addr, e)
                 print(str)
             return False
         return True
@@ -115,13 +148,22 @@ class GreenPackSMBusAdapter(GreenPakI2cInterface):
     def read(
         self, addr: int, byte_count: int, silent: bool = False
     ) -> bytearray | None:
-        offset = 0
-        data = []
-        while byte_count > 0:
-            #smbus layer would support upto 32b in single op, but our pages are 
-            #len 16, so keep same?
-            xferlen = min(16, byte_count)
-            data.extend(self.bus.read_i2c_block_data(addr, offset, xferlen))
-            offset += xferlen
-            byte_count -= xferlen
-        return data
+        try:
+            if 0 == byte_count:
+                #assume caller probing for GP devs on bus
+                self.__empty_rd(addr)  #Can/will throw if no dev found.
+                return bytearray()
+            else:
+                offset = 0
+                data = []
+                while byte_count > 0:
+                    xferlen = min(self.smbus2.I2C_SMBUS_BLOCK_MAX, byte_count)
+                    data.extend(self.bus.read_i2c_block_data(addr, offset, xferlen))
+                    offset += xferlen
+                    byte_count -= xferlen
+                return bytearray(data)
+        except Exception as e:
+            if not silent:
+                str = "SMBus: while reading at addr 0x%02x: caught exception: %s" % (addr, e)
+                print(str)
+        return None

--- a/src/greenpak/i2c.py
+++ b/src/greenpak/i2c.py
@@ -2,7 +2,7 @@
 
 from i2c_adapter import I2cAdapter
 from i2cdriver import I2CDriver
-from typing import override
+from typing_extensions import override
 
 
 class GreenPakI2cInterface:

--- a/src/greenpak/utils.py
+++ b/src/greenpak/utils.py
@@ -146,5 +146,5 @@ def hex_dump(data: bytearray | bytes, start_addr: int = 0) -> None:
                 items.append(f"{col_space}  ")
             else:
                 items.append(f"{col_space}{data[addr - start_addr]:02x}")
-        print(f"{row_addr:02x}: {" ".join(items)}", flush=True)
+        print(f'{row_addr:02x}: {" ".join(items)}', flush=True)
         row_addr += 16

--- a/test/smb_test.py
+++ b/test/smb_test.py
@@ -1,0 +1,72 @@
+#This file contains example purely for exercising the greenpak driver using
+#SMBUs adapter. There is no other purpose and it does nothing useful.
+
+import sys
+sys.path.append('./src/greenpak/')
+from greenpak import driver, utils, i2c
+from i2c import GreenPakI2cInterface, GreenPackSMBusAdapter
+from utils import hex_dump
+
+# def hexdump(data, showaddr=0):
+#     offset = 0
+#     while offset < len(data):
+#         line = format(showaddr + offset, '4x') + ':'
+#         count = min(len(data) - offset, 16)
+#         for i in range(count):
+#             line += ' ' + format(data[offset + i], '02x')
+#         print(line)
+#         offset += count
+
+print("Testing...")
+i2c_driver = i2c.GreenPackSMBusAdapter()
+
+# --- Test of emptiness  ---
+print("empty read/write to non-attached ...")
+#Use some invalid (not connected) address, to test them empty reads/writes.
+bad_addr = 0x20
+i2c_driver.read(bad_addr, 0, False)
+i2c_driver.write(bad_addr, bytearray(), False)
+good_addr = 0x8
+print("empty read/write to an attached...")
+if None != i2c_driver.read(good_addr, 0, False):
+  print("RD: found it.")
+if True == i2c_driver.write(good_addr, bytearray(), False):
+   print("WR: found it.")
+
+#print("GreenPackSMBusAdapter is subclass of GreenPakI2cInterface:", issubclass(GreenPackSMBusAdapter, GreenPakI2cInterface))
+#print("Type of GreenPackSMBusAdapter instance:", type(i2c_driver))
+
+slg_code = 0b0010
+gp_driver = driver.GreenpakDriver(i2c_driver, device_type="SLG46826", device_control_code=slg_code)
+print( gp_driver.get_device_type() )
+
+found = True
+
+try:
+  reg_bytes = gp_driver.read_register_bytes(0, 256)
+  print("~ Dumping reg mem ... ~")
+  hex_dump(reg_bytes)
+except Exception as e:
+    print(f' Likely NO device at your control code 0x{slg_code:02x} !')
+    found = False
+
+if not found:
+  print("Scanning for GreenPak control codes:")
+  for control_code in gp_driver.scan_greenpak_devices():
+      print(f"* Potential GreenPak device at control code 0x{control_code:02x}")
+      slg_code = control_code
+      found = True
+
+if found:
+  gp_driver.set_device_control_code(slg_code)
+  gp_driver.reset_device()
+  reg_bytes = gp_driver.read_register_bytes(0, 256)
+  #print("Type of reg_bytes:", type(reg_bytes))
+  print("~ Dumping reg mem ... ~")
+  hex_dump(reg_bytes)
+  nvm_bytes = gp_driver.read_nvm_bytes(0, 256)
+  print("~ Dumping nvm mem ... ~")
+  hex_dump(nvm_bytes)
+  eep_bytes = gp_driver.read_eeprom_bytes(0, 256)
+  print("~ Dumping eep mem ... ~")
+  hex_dump(eep_bytes)


### PR DESCRIPTION
Implements #2 
  -GreenPackSMBusAdapter:  This wraps smbus2 interface that (optionally) available on Linux,
   and allows us to use the GreenPakDriver.
