### PR TITLE
src/greenpak/i2c.py: Fix SMBus adapter write.

### DIFF
--- a/src/greenpak/i2c.py
+++ b/src/greenpak/i2c.py
@@ -140,7 +140,15 @@ class GreenPakSMBusAdapter(GreenPakI2cInterface):
                 self.__empty_wr(addr)  # Can throw
             else:
                 # assume data is sent/written
-                self.bus.write_i2c_block_data(addr, data[0], data[1:])
+                regaddr = data[0]
+                regdata = data[1:]
+                bytesleft = len(regdata)
+                offset = 0
+                while bytesleft > 0:
+                    xferlen = min(self.smbus2.I2C_SMBUS_BLOCK_MAX, bytesleft)
+                    self.bus.write_i2c_block_data(addr, regaddr, regdata[offset:offset + xferlen])
+                    offset += xferlen
+                    bytesleft -= xferlen
         except Exception as e:
             if not silent:
                 str = "SMBus: while writing to addr 0x%02x: caught exception: %s" % (

--- a/test/smb_test.py
+++ b/test/smb_test.py
@@ -70,3 +70,6 @@ if found:
   eep_bytes = gp_driver.read_eeprom_bytes(0, 256)
   print("~ Dumping eep mem ... ~")
   hex_dump(eep_bytes)
+  print("~tesing write to reg mem...~")
+  data = utils.read_bits_config_file("./test/test_data/slg46826_blinky_slow.txt")
+  gp_driver.write_register_bytes(0, data)


### PR DESCRIPTION
Fixes write by splitting - same as read was doing.  Tested.

Could we merge this before I update https://github.com/zapta/greenpak/pull/5  per your latest comments.

@zapta 