### PR TITLE
Add BusPirate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ A Python package to access and program Renesas GreenPak SPLD's.
 
 This Python package provides a simple to use API to read/write/program Renseas GreenPak PLDs over a USB to I2C link. 
 
-As of December 2023, the package supports the following USB to I2C interfaces and new ones can be easily added based on the examples in [i2c.py](https://github.com/zapta/greenpak/blob/main/src/greenpak/i2c.py): 
+As of May 2025, the package supports the following USB to I2C interfaces and new ones can be easily added based on the examples in [i2c.py](https://github.com/zapta/greenpak/blob/main/src/greenpak/i2c.py): 
 * [I2C Driver](https://pypi.org/project/i2cdriver/) (two variants, mini and full.)
 * [I2C Adapter](https://pypi.org/project/i2c-adapter/) (four variants, including a bare Raspberry Pico.)
+* [Bus Pirate](https://dangerousprototypes.com/docs/Bus_Pirate) (v2, v3 and v4)
 
 Sample usage using an [I2C Adapter](https://pypi.org/project/i2c-adapter):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "greenpak"
-version = "0.0.28"
+version = "0.0.29"
 authors = [
   { name="Zapta", email="zapta@zapta.com" },
 ]
@@ -28,6 +28,7 @@ dependencies = [
     "i2cdriver >=1.0.1",
     "intelhex>=2.3.0",
     "smbus2==0.4.3",
+    "hackPyrateBus>=0.0.6",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/test/bp_eeprom_test.py
+++ b/test/bp_eeprom_test.py
@@ -1,0 +1,45 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath('../src'))
+print(f"*** sys.path: {sys.path}")
+
+from greenpak import driver, i2c, utils
+import random
+from time import sleep
+
+port="/dev/buspirate"
+
+
+print("\nConnecting.")
+i2c_driver = i2c.GreenPakBusPirate(port = port)
+gp_driver = driver.GreenpakDriver(i2c_driver, device_type="SLG46826", device_control_code=0b0001)
+
+print("Generating random data.")
+data = bytearray()
+for _ in range(256):
+    data.append(random.randint(0, 255))
+utils.hex_dump(data)
+
+print("Programming the EEPROM with the random data.")
+gp_driver.program_eeprom_pages(0, data)
+
+print ("\nReading the EEPROM.")
+read_data = gp_driver.read_eeprom_bytes(0, 256)
+utils.hex_dump(read_data)
+
+if data == read_data:
+    print ("EEPROM data verification succeeded.")
+else:
+    print ("EEPROM data verification failed.")
+
+print("Erasing the EEPROM")
+i2c_addr = gp_driver.get_device_control_code() << 3
+for page in range(16):
+    i2c_driver.gp_write(i2c_addr, 0xe3, [0x90 + page])
+sleep(0.025)
+read_data = gp_driver.read_eeprom_bytes(0, 256)
+assert all(byte == 0 for byte in read_data)
+
+print("Resetting the device.")
+gp_driver.reset_device()

--- a/test/bp_test.py
+++ b/test/bp_test.py
@@ -1,0 +1,45 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath('../src'))
+print(f"*** sys.path: {sys.path}")
+
+from greenpak import driver, i2c, utils
+
+
+port="/dev/buspirate"
+config_file = "test_data/slg46826_blinky_slow.txt"
+
+
+print("\nConnecting.")
+i2c_driver = i2c.GreenPakBusPirate(port = port)
+gp_driver = driver.GreenpakDriver(i2c_driver, device_type="SLG46826", device_control_code=0b0001)
+
+print("\nI2C scanning:")
+for addr in range(0, 128):
+  if i2c_driver.gp_write(addr, 0, []):
+    print(f"* I2C device at address 0x{addr:02x}")
+
+
+# For information only. Scan the I2C bus for greenpak device. 
+print("\nGreenPak scanning:")
+devices = gp_driver.scan_greenpak_devices()
+for control_code in devices:
+  print(f"* Potential GreenPak device at control code 0x{control_code:02x}")
+
+print("\nLoading configuration.")
+data = utils.read_bits_config_file(config_file)
+utils.hex_dump(data)
+
+print("\nProgramming the NVM.")
+gp_driver.program_nvm_pages(0, data)
+
+print ("\nReading the NVM.")
+data = gp_driver.read_nvm_bytes(0, 256)
+utils.hex_dump(data)
+
+print ("\nWriting config to a file.")
+utils.write_bits_config_file("_output_file.txt", data)
+
+print("\nResetting the device.")
+gp_driver.reset_device()

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,4 @@ greenpak
 i2cdriver
 typing_extensions
 smbus2
+hackPyrateBus


### PR DESCRIPTION
Cannot get pyBusPirateLite library from PyPI, so had to use another package that vends it. Ideally somebody publishes this library to PyPI and we can import it directly.

This commit also includes two test files that verifies the changes for NVM and EEPROM operations using BusPirate.