### PR TITLE
Fix typing_extensions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "intelhex>=2.3.0",
     "smbus2==0.4.3",
     "hackPyrateBus>=0.0.6",
+    "typing_extensions>=4.7.1",
 ]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
Although this library is being used in greenpak.i2c, it was not part of the package dependencies and required installing manually. Adding this to the dependencies should fix any errors.